### PR TITLE
digital: fixed ofdm benchmark_tx. flowgraph was closing down before tx q...

### DIFF
--- a/gr-digital/examples/ofdm/benchmark_tx.py
+++ b/gr-digital/examples/ofdm/benchmark_tx.py
@@ -114,7 +114,8 @@ def main():
         pktno += 1
         
     send_pkt(eof=True)
-    tb.wait()                       # wait for it to finish
+    time.sleep(2)               # allow time for queued packets to be sent
+    tb.wait()                   # wait for it to finish
 
 if __name__ == '__main__':
     try:


### PR DESCRIPTION
...ueue was empty
